### PR TITLE
Mattffffff/breakingchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,9 @@ The module will check for duplicate subscription IDs in the file and fail at the
 
 The default parent is the root tenant group.
 
-You can specify an alternate parent management group using either:
+You can specify an alternate parent management group using:
 
-* parent_management_group_display_name
-* parent_management_group_id
-
-Only one of these is required.
+* parent_management_group_name
 
 ## Permissions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ For an overview, please read the [Management Groups](https://docs.microsoft.com/
 
 The default value for the input structure is based on [Enterprise-Scale](https://github.com/Azure/Enterprise-Scale).
 
-The input object has `type = any` for greater flexibility, including a mix and match of children and subscription ID lists at the same scope points. There is currently no use of type constraints or variable validation.
+The input object has `type = any` for greater flexibility, including a mix and match of children and optional `display_name` attributes at the same scope points. There is currently no use of type constraints or variable validation in this object.
+
+> Note that the management group name must contain only ASCII letters, digits, numbers, _, -, (, ) .
 
 The main key names map to the created Management Group `name` property. This cannot be changed once created. The `display_name` property can be optionally specified if you would like it to be different than the name.
 

--- a/main.tf
+++ b/main.tf
@@ -5,23 +5,23 @@ terraform {
 data "azurerm_subscription" "current" {}
 
 locals {
-  parent               = var.parent_management_group_display_name != null || var.parent_management_group_id != null ? true : false
+  parent               = var.parent_management_group_name != null ? true : false
   tenant_root_group_id = "/providers/Microsoft.Management/managementGroups/${data.azurerm_subscription.current.tenant_id}"
 }
 
 
 data "azurerm_management_group" "parent" {
-  for_each     = toset(local.parent ? ["Named"] : [])
-  display_name = var.parent_management_group_display_name
-  name         = var.parent_management_group_id
+  for_each = toset(local.parent ? ["Named"] : [])
+  name     = var.parent_management_group_name
 }
 
 module "mg1" {
   source   = "./modules/mg1"
   for_each = var.management_groups
 
-  level                      = 1
-  display_name               = each.key
-  parent_management_group_id = local.parent ? data.azurerm_management_group.parent["Named"].id : local.tenant_root_group_id
-  children                   = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = 1
+  name                        = each.key
+  parent_management_group_id  = local.parent ? data.azurerm_management_group.parent["Named"].id : local.tenant_root_group_id
+  children                    = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,9 @@ data "azurerm_subscription" "current" {}
 locals {
   parent               = var.parent_management_group_name != null ? true : false
   tenant_root_group_id = "/providers/Microsoft.Management/managementGroups/${data.azurerm_subscription.current.tenant_id}"
-  // This local checks for duplicate subscription IDs in the CSV
-  // It is not used in the plan but is useful to prevent failures on apply
   subscription_to_mg_csv_data_check = {
+    // This local checks for duplicate subscription IDs in the CSV
+    // It is not used in the plan but is useful to prevent failures on apply
     for s in var.subscription_to_mg_csv_data :
     s.subId => s.mgName
   }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,12 @@ data "azurerm_subscription" "current" {}
 locals {
   parent               = var.parent_management_group_name != null ? true : false
   tenant_root_group_id = "/providers/Microsoft.Management/managementGroups/${data.azurerm_subscription.current.tenant_id}"
+  // This local checks for duplicate subscription IDs in the CSV
+  // It is not used in the plan but is useful to prevent failures on apply
+  subscription_to_mg_csv_data_check = {
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName
+  }
 }
 
 

--- a/modules/mg1/main.tf
+++ b/modules/mg1/main.tf
@@ -1,19 +1,22 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
 
   children = {
     for key, value in var.children :
-    key => value if key != "subscription_ids"
+    key => value if key != "display_name"
   }
 
   next_level = var.level + 1
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }
@@ -22,8 +25,9 @@ module "mg2" {
   source   = "../mg2"
   for_each = local.children // var.level + 1 == 2 ? local.children : {}
 
-  level                          = local.next_level
-  display_name                   = each.key
-  parent_management_group_id     = azurerm_management_group.mg.id
-  children                       = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = local.next_level
+  name                        = each.key
+  parent_management_group_id  = azurerm_management_group.mg.id
+  children                    = each.value
 }

--- a/modules/mg1/variables.tf
+++ b/modules/mg1/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/modules/mg2/main.tf
+++ b/modules/mg2/main.tf
@@ -1,19 +1,22 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
 
   children = {
     for key, value in var.children :
-    key => value if key != "subscription_ids"
+    key => value if key != "display_name"
   }
 
   next_level = var.level + 1
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }
@@ -22,8 +25,9 @@ module "mg3" {
   source   = "../mg3"
   for_each = local.children // var.level + 1 == 2 ? local.children : {}
 
-  level                          = local.next_level
-  display_name                   = each.key
-  parent_management_group_id     = azurerm_management_group.mg.id
-  children                       = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = local.next_level
+  name                        = each.key
+  parent_management_group_id  = azurerm_management_group.mg.id
+  children                    = each.value
 }

--- a/modules/mg2/variables.tf
+++ b/modules/mg2/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/modules/mg3/main.tf
+++ b/modules/mg3/main.tf
@@ -1,19 +1,22 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
 
   children = {
     for key, value in var.children :
-    key => value if key != "subscription_ids"
+    key => value if key != "display_name"
   }
 
   next_level = var.level + 1
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }
@@ -22,8 +25,9 @@ module "mg4" {
   source   = "../mg4"
   for_each = local.children // var.level + 1 == 2 ? local.children : {}
 
-  level                          = local.next_level
-  display_name                   = each.key
-  parent_management_group_id     = azurerm_management_group.mg.id
-  children                       = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = local.next_level
+  name                        = each.key
+  parent_management_group_id  = azurerm_management_group.mg.id
+  children                    = each.value
 }

--- a/modules/mg3/variables.tf
+++ b/modules/mg3/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/modules/mg4/main.tf
+++ b/modules/mg4/main.tf
@@ -1,19 +1,22 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
 
   children = {
     for key, value in var.children :
-    key => value if key != "subscription_ids"
+    key => value if key != "display_name"
   }
 
   next_level = var.level + 1
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }
@@ -22,8 +25,9 @@ module "mg5" {
   source   = "../mg5"
   for_each = local.children // var.level + 1 == 2 ? local.children : {}
 
-  level                          = local.next_level
-  display_name                   = each.key
-  parent_management_group_id     = azurerm_management_group.mg.id
-  children                       = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = local.next_level
+  name                        = each.key
+  parent_management_group_id  = azurerm_management_group.mg.id
+  children                    = each.value
 }

--- a/modules/mg4/variables.tf
+++ b/modules/mg4/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/modules/mg5/main.tf
+++ b/modules/mg5/main.tf
@@ -1,19 +1,22 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
 
   children = {
     for key, value in var.children :
-    key => value if key != "subscription_ids"
+    key => value if key != "display_name"
   }
 
   next_level = var.level + 1
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }
@@ -22,8 +25,9 @@ module "mg6" {
   source   = "../mg6"
   for_each = local.children // var.level + 1 == 2 ? local.children : {}
 
-  level                      = local.next_level
-  display_name               = each.key
-  parent_management_group_id = azurerm_management_group.mg.id
-  children                   = each.value
+  subscription_to_mg_csv_data = var.subscription_to_mg_csv_data
+  level                       = local.next_level
+  name                        = each.key
+  parent_management_group_id  = azurerm_management_group.mg.id
+  children                    = each.value
 }

--- a/modules/mg5/variables.tf
+++ b/modules/mg5/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/modules/mg6/main.tf
+++ b/modules/mg6/main.tf
@@ -1,12 +1,15 @@
 locals {
-  subscription_ids = flatten([
-    for key, value in var.children :
-    key == "subscription_ids" ? toset(value) : []
-  ])
+  display_name = lookup(var.children, "display_name", var.name)
+
+  subscription_ids = keys({
+    for s in var.subscription_to_mg_csv_data :
+    s.subId => s.mgName if s.mgName == var.name
+  })
 }
 
 resource "azurerm_management_group" "mg" {
-  display_name               = var.display_name
+  display_name               = local.display_name
+  name                       = var.name
   parent_management_group_id = var.parent_management_group_id
   subscription_ids           = local.subscription_ids
 }

--- a/modules/mg6/variables.tf
+++ b/modules/mg6/variables.tf
@@ -2,7 +2,9 @@ variable "level" {
   type = number
 }
 
-variable "display_name" {}
+variable "subscription_to_mg_csv_data" {}
+
+variable "name" {}
 
 variable "parent_management_group_id" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-variable "parent_management_group_id" {
+variable "parent_management_group_name" {
   // The scope at which to create the management groups
   // If unspecified then will default to root tenant group, but this requires special permissions
   // <https://docs.microsoft.com/azure/governance/management-groups/overview>
@@ -7,8 +7,13 @@ variable "parent_management_group_id" {
   default = null
 }
 
-variable "parent_management_group_display_name" {
+/* variable "parent_management_group_display_name" {
   type    = string
+  default = null
+} */
+
+variable "subscription_to_mg_csv_data" {
+  type    = any
   default = null
 }
 
@@ -18,18 +23,33 @@ variable "management_groups" {
 
   type = any
 
+  // The keys in this object are the Management Group name.
+  // The name can only be an ASCII letter, digit, -, _, (, )
+  // Specifying display_name is optional. If omitted the name is used.
   default = {
-    "Landing Zones" = {
-      "Corp"   = {},
-      "Online" = {}
-    },
-    "Platform" = {
-      "Management" = {},
-      "Connectivity" = {
-        subscription_ids = ["2d31be49-d959-4415-bb65-8aec2c90ba62"]
-
+    "ES" = {
+      display_name = "ES"
+      "ES-LandingZones" = {
+        display_name = "LandingZones"
+        "ES-Corp" = {
+          display_name = "Corp"
+        },
+        "ES-Online" = {
+          display_name = "Online"
+        }
       },
-      "Identity" = {},
+      "ES-Platform" = {
+        display_name = "Platform"
+        "ES-Management" = {
+          display_name = "Management"
+        },
+        "ES-Connectivity" = {
+          display_name = "Connectivity"
+        },
+        "ES-Identity" = {
+          display_name = "Identity"
+        },
+      }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,12 +7,11 @@ variable "parent_management_group_name" {
   default = null
 }
 
-/* variable "parent_management_group_display_name" {
-  type    = string
-  default = null
-} */
-
 variable "subscription_to_mg_csv_data" {
+  // This variable should be the csvdecode() output of a two column CSV file, e.g.:
+  // subId,mgName
+  // 167d4f7a-0484-44f1-a84f-93f07ff3c798,ES-LandingZones
+
   type    = any
   default = null
 }
@@ -26,6 +25,7 @@ variable "management_groups" {
   // The keys in this object are the Management Group name.
   // The name can only be an ASCII letter, digit, -, _, (, )
   // Specifying display_name is optional. If omitted the name is used.
+
   default = {
     "ES" = {
       display_name = "ES"


### PR DESCRIPTION
I'd like to discuss some changes to this module based on customer feedback and application in 'subscription vending machine' scenarios.

The changes here are:

1. Use of MG name property as the keys in the input map
2. Optionally you can now specify the display_name if you want it to be different
3. Use of CSV data to store subscription to management group mappings.

The switch from display_name to name provides added rigour, as the name property cannot be changed. This is therefore safer when using the outputs of the module. Customer feedback was that they didn't want a UUID as the name, they wanted something that made more sense to a human.

On the use of CSV... consider the use of this module in an automated subscription creation scenario. Editing a complex object is hard to do in code, whereas using a CSV means it's easy to append another line. The module has checks for uniqueness of the subscription IDs in being submitted.

I realise this means breaking changes, but maybe a new major version could be used? e.g. v2.0.0